### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "ext-mbstring": "*",
-        "laravel/framework": "~5.4"
+        "laravel/framework": "5.4.* || 5.5.*"
     },
     "require-dev": {
-        "laravel/laravel": "~5.4",
+        "laravel/laravel": "5.4.* || 5.5.*",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "~5.7 || ^6.4"
     },


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.