### PR TITLE
Draft: Change body and chassis min length to 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Changed
+
+- Minimal valid length of `body_code` and `chassis_code` is 8 symbols
+
 ## v3.8.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Changed
 
-- Minimal valid length of `body_code` and `chassis_code` is 8 symbols
+- Minimal valid length of `chassis_code` and `body_code` is 8 symbols
 
 ## v3.8.0
 

--- a/src/Extensions/BodyCodeValidatorExtension.php
+++ b/src/Extensions/BodyCodeValidatorExtension.php
@@ -46,7 +46,7 @@ class BodyCodeValidatorExtension extends AbstractValidatorExtension
             $length = Str::length($uppercase);
 
             $stack[$value] = (
-                $length >= 7 && $length <= 15 // Проверяем соответствие минимальной и максимальной длине
+                $length >= 8 && $length <= 15 // Проверяем соответствие минимальной и максимальной длине
                 && \preg_match('~\d~', $value) === 1 // Содержит числа
                 // Соответствует ли шаблону
                 && \preg_match("~^[{$kyr_chars}A-Z\d]{2,}(\-|\s|)[{$kyr_chars}A-Z\d]{2,9}$~iu", $uppercase) === 1

--- a/tests/Extensions/BodyCodeValidatorExtensionTest.php
+++ b/tests/Extensions/BodyCodeValidatorExtensionTest.php
@@ -40,6 +40,7 @@ class BodyCodeValidatorExtensionTest extends AbstractExtensionTestCase
             'ZZT241-000700412',
 
             // Слишком короткие
+            '0685256',
             '068525',
             '06852',
             '0685',
@@ -82,7 +83,6 @@ class BodyCodeValidatorExtensionTest extends AbstractExtensionTestCase
     protected function getValidValues(): array
     {
         return [
-            '0685251',
             'AT2113041080',
             'NZE141-9134919',
             'GD11231271',


### PR DESCRIPTION
## Description

### Changed

- Minimal valid length of `body_code` and `chassis_code` is 8 symbols