### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,15 +21,10 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['8.1', '8.2', '8.3']
-        include:
-          - php: '8.1'
-            setup: [ basic, lowest ]
-            coverage: no
-            laravel: '^10.0'
+        php: ['8.2', '8.3', '8.4', '8.5']
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 # Action page: <https://github.com/shivammathur/setup-php>
@@ -42,7 +37,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         run: echo "output_dir=dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies # Docs: <https://git.io/JfAKn#php---composer>
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ steps.composer-cache.outputs.output_dir }}
           key: ${{ runner.os }}-composer-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
@@ -73,11 +68,11 @@ jobs: # Docs: <https://git.io/JvxXE>
           XDEBUG_MODE: coverage
         run: composer test-cover
 
-      - uses: codecov/codecov-action@v4 # Docs: <https://github.com/codecov/codecov-action>
+      - uses: codecov/codecov-action@v7 # Docs: <https://github.com/codecov/codecov-action>
         if: matrix.coverage == 'yes'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage/clover.xml
+          files: ./coverage/clover.xml
           flags: php
           fail_ci_if_error: false
 
@@ -86,7 +81,7 @@ jobs: # Docs: <https://git.io/JvxXE>
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Lint changelog file
         uses: docker://avtodev/markdown-lint:v1 # Action page: <https://github.com/avto-dev/markdown-lint>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
-## Unreleased
+## v5.1.0
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Laravel `13.x` support
+
+### Changed
+
+- Minimal Laravel version now is `^11.0`
+- Version of `composer` in docker container updated up to `2.10.`
+- Version of `php` in docker container updated up to `8.5`
+- Update dev dependencies
+
 ## v5.0.0
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM php:8.3-alpine
+FROM php:8.5-alpine
 
 ENV COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:2.8.9 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.10.2 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \
     && apk add --no-cache --virtual .build-deps linux-headers autoconf pkgconf make g++ gcc 1>/dev/null \
     # install xdebug (for testing with code coverage), but do not enable it
-    && pecl install xdebug-3.3.0 1>/dev/null \
+    && pecl install xdebug 1>/dev/null \
     && apk del .build-deps \
     && mkdir --parents --mode=777 /src ${COMPOSER_HOME}/cache/repo ${COMPOSER_HOME}/cache/files \
     && ln -s /usr/bin/composer /usr/bin/c \

--- a/composer.json
+++ b/composer.json
@@ -16,17 +16,17 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "illuminate/contracts": "~10.0 || ~11.0 || ~12.0",
-        "illuminate/container": "~10.0 || ~11.0 || ~12.0",
-        "illuminate/support": "~10.0 || ~11.0 || ~12.0",
-        "illuminate/validation": "~10.0 || ~11.0 || ~12.0",
-        "illuminate/config": "~10.0 || ~11.0 || ~12.0"
+        "php": "^8.2",
+        "illuminate/contracts": "~11.0 || ~12.0 || ~13.0",
+        "illuminate/container": "~11.0 || ~12.0 || ~13.0",
+        "illuminate/support": "~11.0 || ~12.0 || ~13.0",
+        "illuminate/validation": "~11.0 || ~12.0 || ~13.0",
+        "illuminate/config": "~11.0 || ~12.0 || ~13.0"
     },
     "require-dev": {
-        "laravel/laravel": "~10.0 || ~11.0 || ~12.0",
-        "mockery/mockery": "^1.6.5",
-        "phpstan/phpstan": "^1.10.66",
+        "laravel/laravel": "~11.0 || ~12.0 || ~13.0",
+        "mockery/mockery": "^1.6.10",
+        "phpstan/phpstan": "^1.12",
         "phpunit/phpunit": "^10.5"
     },
     "autoload": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.2'
-
 volumes:
   composer-data:
 


### PR DESCRIPTION
## Description

### Added

- Laravel `13.x` support

### Changed

- Minimal Laravel version now is `^11.0`
- Version of `composer` in docker container updated up to `2.10.`
- Version of `php` in docker container updated up to `8.5`
- Update dev dependencies

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file